### PR TITLE
Make `color-rg-search' respect more regular expressions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <img src="./screenshot/color-rg.png">
 
 # What is color-rg?
-color-rg is search and refacotry tool base on ripgrep.
+color-rg is search and refactoring tool based on ripgrep.
 
-I'm a big fans of color-moccur.el, this extension's name is used for tribute color-moccur.el!
+I'm a big fan of color-moccur.el, this extension's name is used for tribute color-moccur.el!
 
 ## Installation
 

--- a/color-rg.el
+++ b/color-rg.el
@@ -304,7 +304,7 @@ This function is called from `compilation-filter-hook'."
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; Utils functions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defun color-rg-search (keyword directory)
-  (let* ((search-command (format "rg %s %s --column --color=always" keyword directory)))
+  (let* ((search-command (format "rg --regexp \"%s\" %s --column --color=always" keyword directory)))
     ;; Erase or create search result.
     (if (get-buffer color-rg-buffer)
         (let ((inhibit-read-only t))


### PR DESCRIPTION
Without the double quotes around the `keyword`, regex such as `'.*foobar.*'` (foobar inside single quotes) would be the same as `.*foobar.*`.

Also added the `--regexp` option, according to the manual of rg:

> -e, --regexp PATTERN ...
>     A pattern to search for. This option can be provided multiple times, where all patterns given are searched. Lines matching at least one of the
>     provided patterns are printed. This flag can also be used when searching for patterns that start with a dash.