### PR TITLE
Make literal search escape double quote and bashslash.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ Bind your favorite key to functions:
 | f          | Filter results match regexp                     |
 | F          | Filter results not match regexp                 |
 | D          | Delete current line from results                |
-| s          | Re-search with new keyword                      |
+| s          | Re-search with new keyword and default argument |
 | d          | Re-search with new directory                    |
 | i          | Toggle to include or exclude the ignore files   |
 | c          | Toggle to smart case or case sensitive          |
-| t          | Toggle to search pattern as literal or regexp   |
+| t          | Re-search pattern as literal                    |
 | m          | Re-search with customized rg argument           |
 | e          | Enable edit mode                                |
 | q          | Quit                                            |

--- a/color-rg.el
+++ b/color-rg.el
@@ -634,6 +634,7 @@ This function is called from `compilation-filter-hook'."
   (with-current-buffer color-rg-buffer
     (let* ((new-directory (read-file-name (format "Re-search with new directory: ") search-directory)))
       (color-rg-switch-to-view-mode)
+      (set (make-local-variable 'default-directory) new-directory)
       (color-rg-search-input search-keyword new-directory search-argument)
       (set (make-local-variable 'search-directory) new-directory)
       )))

--- a/color-rg.el
+++ b/color-rg.el
@@ -625,18 +625,36 @@ This function is called from `compilation-filter-hook'."
   (with-current-buffer color-rg-buffer
     (let* ((new-keyword (read-string (format "Re-search with new keyword: ") search-keyword)))
       (color-rg-switch-to-view-mode)
-      (color-rg-search-input new-keyword search-directory search-argument)
+      (color-rg-search-input new-keyword search-directory)
       (set (make-local-variable 'search-keyword) new-keyword)
       )))
+
+(defun color-rg-literal-search-helper (search-argument)
+  (if (cl-search (regexp-quote "--fixed-strings") search-argument)
+      t
+    nil))
+
+(defun color-rg-literal-string-escape (string)
+  "escape double quote and backslash."
+  (replace-regexp-in-string (regexp-quote "\"") "\\\\\""
+                                      (replace-regexp-in-string (regexp-quote "\\") "\\\\\\\\"
+                                                                string)
+                                      ))
 
 (defun color-rg-change-search-directory ()
   (interactive)
   (with-current-buffer color-rg-buffer
-    (let* ((new-directory (read-file-name (format "Re-search with new directory: ") search-directory)))
+    (let* ((new-directory (read-file-name (format "Re-search with new directory: ") search-directory))
+           (original-keyword search-keyword)
+           (literal-search (color-rg-literal-search-helper search-argument))
+           (new-keyword (if literal-search
+                            (color-rg-literal-string-escape search-keyword)
+                          original-keyword)))
       (color-rg-switch-to-view-mode)
       (set (make-local-variable 'default-directory) new-directory)
-      (color-rg-search-input search-keyword new-directory search-argument)
+      (color-rg-search-input new-keyword new-directory search-argument)
       (set (make-local-variable 'search-directory) new-directory)
+      (set (make-local-variable 'search-keyword) original-keyword)
       )))
 
 (defun color-rg-change-search-customized ()
@@ -648,18 +666,26 @@ This function is called from `compilation-filter-hook'."
       (set (make-local-variable 'search-argument) new-argument)
       )))
 
+
 (defun color-rg-rerun-literal ()
   (interactive)
   (with-current-buffer color-rg-buffer
-    (let* ((new-argument (cond ((cl-search (regexp-quote "--regexp") search-argument)
+    (let* (
+           (new-argument (cond ((cl-search (regexp-quote "--regexp") search-argument)
                                 (replace-regexp-in-string (regexp-quote "--regexp") "--fixed-strings" search-argument))
                                ((cl-search (regexp-quote "--fixed-strings") search-argument)
-                                (replace-regexp-in-string (regexp-quote "--fixed-strings") "--regexp" search-argument))
-                               (t color-rg-default-argument))))
+                                search-argument)
+                               (t
+                                (replace-regexp-in-string (regexp-quote "--regexp") "--fixed-strings" color-rg-default-argument))
+                               ))
+           (input-keyword (read-string (format "Re-search with literal: ") search-keyword))
+           (literal-keyword
+            (color-rg-literal-string-escape input-keyword)))
 
       (color-rg-switch-to-view-mode)
-      (color-rg-search-input search-keyword search-directory new-argument)
+      (color-rg-search-input literal-keyword search-directory new-argument)
       (set (make-local-variable 'search-argument) new-argument)
+      (set (make-local-variable 'search-keyword) input-keyword)
       )))
 
 (defun color-rg-rerun-no-ignore ()
@@ -667,10 +693,16 @@ This function is called from `compilation-filter-hook'."
   (with-current-buffer color-rg-buffer
     (let* ((new-argument (if (cl-search (regexp-quote "--no-ignore") search-argument)
                              (replace-regexp-in-string (regexp-quote "--no-ignore ") "" search-argument)
-                           (concat "--no-ignore " search-argument))))
+                           (concat "--no-ignore " search-argument)))
+           (original-keyword search-keyword)
+           (literal-search (color-rg-literal-search-helper new-argument))
+           (new-keyword (if literal-search
+                            (color-rg-literal-string-escape search-keyword)
+                          original-keyword)))
       (color-rg-switch-to-view-mode)
-      (color-rg-search-input search-keyword search-directory new-argument)
+      (color-rg-search-input new-keyword search-directory new-argument)
       (set (make-local-variable 'search-argument) new-argument)
+      (set (make-local-variable 'search-keyword) original-keyword)
       )))
 
 (defun color-rg-rerun-case-senstive ()
@@ -680,10 +712,17 @@ This function is called from `compilation-filter-hook'."
                                 (replace-regexp-in-string (regexp-quote "--smart-case") "--case-sensitive" search-argument))
                                ((cl-search (regexp-quote "--case-sensitive") search-argument)
                                 (replace-regexp-in-string (regexp-quote "--case-sensitive") "--smart-case" search-argument))
-                               (t color-rg-default-argument))))
+                               (t color-rg-default-argument)))
+           (original-keyword search-keyword)
+           (literal-search (color-rg-literal-search-helper new-argument))
+           (new-keyword (if literal-search
+                            (color-rg-literal-string-escape search-keyword)
+                          original-keyword))
+           )
       (color-rg-switch-to-view-mode)
-      (color-rg-search-input search-keyword search-directory new-argument)
+      (color-rg-search-input new-keyword search-directory new-argument)
       (set (make-local-variable 'search-argument) new-argument)
+      (set (make-local-variable 'search-keyword) original-keyword)
       )))
 
 (defun isearch-toggle-color-rg ()


### PR DESCRIPTION
1. Type t to launch literal search. What you input is what your search
for.
2. Type s to search with default arguments again.
3. modify readme.