### PR TITLE
fix regex error on macOS #29

### DIFF
--- a/color-rg.el
+++ b/color-rg.el
@@ -530,7 +530,7 @@ This function is called from `compilation-filter-hook'."
                    ((string-prefix-p "exited abnormally with code" msg)
                     ;; Switch to literal search automaticity when parsing keyword regexp failed.
                     (with-current-buffer color-rg-buffer
-                      (cond ((search-forward-regexp "^Error parsing regex near" nil t)
+                      (cond ((or (search-forward-regexp "^Error parsing regex near" nil t) (search-forward-regexp "^regex parse error" nil t))
                              (run-at-time "2sec" nil
                                           (lambda ()
                                             (message "COLOR-RG: parsing keyword regexp failed, switch to literal search automaticity.")))


### PR DESCRIPTION
```
-*- mode: color-rg; default-directory: "~/.emacs.d/" -*-
color-rg started at Tue Apr 23 12:04:49

rg --column --color=always --heading --smart-case -e \+asdjfsj ~/.emacs.d/
regex parse error:
    +asdjfsj
    ^
error: repetition operator missing expression

color-rg
```