### PR TITLE
Add quotes to search-directory in `color-rg-search-input' to support dir with blank space

### DIFF
--- a/color-rg.el
+++ b/color-rg.el
@@ -1125,8 +1125,9 @@ This assumes that `color-rg-in-string-p' has already returned true, i.e.
               default-directory))
          (search-globs
           (or globs
-              "everything")))
-    (color-rg-search search-keyboard search-directory search-globs)))
+              "everything"))
+         (quoted-search-directory (format "\"%s\"" search-directory)))
+    (color-rg-search search-keyboard quoted-search-directory search-globs)))
 
 (defun color-rg-search-symbol ()
   (interactive)


### PR DESCRIPTION
Add patch to search dir with blank space like "c:/Users/Administrator/Downloads/Telegram Desktop/"