### PR TITLE
Fix compatibility issues with doom-emacs

### DIFF
--- a/color-rg.el
+++ b/color-rg.el
@@ -759,6 +759,7 @@ CASE-SENSITIVE determinies if search is case-sensitive."
 
     ;; Run search command.
     (with-current-buffer color-rg-buffer
+      ;; Fix compatibility issues with doom-emacs, because it changed the value of compilation-buffer-name-function.
       (setq-local compilation-buffer-name-function #'compilation--default-buffer-name)
       ;; Start command.
       (compilation-start command 'color-rg-mode)
@@ -804,6 +805,7 @@ user more freedom to use rg with special arguments."
 
     ;; Run search command.
     (with-current-buffer color-rg-buffer
+      ;; Fix compatibility issues with doom-emacs, because it changed the value of compilation-buffer-name-function.
       (setq-local compilation-buffer-name-function #'compilation--default-buffer-name)
       ;; Start command.
       (compilation-start command 'color-rg-mode)

--- a/color-rg.el
+++ b/color-rg.el
@@ -759,6 +759,7 @@ CASE-SENSITIVE determinies if search is case-sensitive."
 
     ;; Run search command.
     (with-current-buffer color-rg-buffer
+      (setq-local compilation-buffer-name-function #'compilation--default-buffer-name)
       ;; Start command.
       (compilation-start command 'color-rg-mode)
 
@@ -803,6 +804,7 @@ user more freedom to use rg with special arguments."
 
     ;; Run search command.
     (with-current-buffer color-rg-buffer
+      (setq-local compilation-buffer-name-function #'compilation--default-buffer-name)
       ;; Start command.
       (compilation-start command 'color-rg-mode)
 


### PR DESCRIPTION
color-rg doesn’t work,  because doom-emacs changed the value of compilation-buffer-name-function.