### PR TITLE
support search compressed file

### DIFF
--- a/color-rg.el
+++ b/color-rg.el
@@ -68,6 +68,9 @@
 
 ;;; Change log:
 ;;
+;; 2020/12/31
+;;      * Add new option `color-rg-search-compressed-file'.
+;;
 ;; 2020/05/04
 ;;      * Add new command `color-rg-insert-current-line'.
 ;;
@@ -319,6 +322,13 @@ Default is enable, set this variable to nil if you don't like this feature."
   "When searching for JS library files, the long JS library file will cause color-rg navigation to be very slow.
 By default, there are 300 columns of restrictions to avoid long file problems."
   :type 'integer
+  :group 'color-rg)
+
+(defcustom color-rg-search-compressed-file nil
+  "Search compressed files when read the emacs source code.
+
+Default is disabled, set this variable to true if you found it's useful"
+  :type 'boolean
   :group 'color-rg)
 
 (defface color-rg-font-lock-header-line-text
@@ -702,6 +712,9 @@ CASE-SENSITIVE determinies if search is case-sensitive."
 
           (when no-ignore
             (list "--no-ignore"))
+
+          (when color-rg-search-compressed-file
+            (list "-z"))
 
           (when (color-rg-is-custom-file-pattern globs)
             (list (concat "--type-add " (shell-quote-argument (concat "custom:" globs)))))


### PR DESCRIPTION
add new option color-rg-search-compressed-file, which could be useful when you read emacs source code like `org-capture.el.gz` 