### PR TITLE
修复了一些文档快捷键错误，以及目录名提示错误。

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,16 @@ Bind your favorite key to functions:
 | X          | Filter results not match file extension                                |
 | u          | Don't filter file extension                                            |
 | D          | Delete current line from results                                       |
-| i          | Toggle to include or exclude the ignore files                          |
-| t          | Re-search pattern as literal                                           |
-| c          | Toggle to smart case or case sensitive                                 |
-| s          | Re-search with new keyword and default argument                        |
-| d          | Re-search with new directory                                           |
-| z          | Re-search with new files                                               |
-| Z          | Rerun last search but prompt for new files which will NOT be searched. |
-| C          | Rerun rg with customized arguments.                                    |
+| L          | Re-search pattern as literal                                           |
+| R          | Re-search pattern as regexp                                           |
+| I          | Toggle to `include`/`exclude` the ignore files then rerun last search           |
+| C          | Toggle to `smart case`/`case sensitive` then rerun last search                    |
+| N          | Toggle to respect `color-rg-search-ignore-rules` then rerun last search                    |
+| O          | Rerun last search in new directory                                           |
+| o          | Rerun last search in (up one level) parent directory                                           |
+| G          | Rerun last search only include specified file type                        |
+| E          | Rerun last search exclude specified file type                        |
+| S          | Rerun rg with customized arguments.                                    |
 | e          | Enable edit mode                                                       |
 | q          | Quit                                                                   |
 

--- a/color-rg.el
+++ b/color-rg.el
@@ -1371,7 +1371,7 @@ This function is the opposite of `color-rg-rerun-change-globs'"
   "Rerun last command but prompt for new dir."
   (interactive)
   (setf (color-rg-search-dir color-rg-cur-search)
-        (read-file-name "In file: "
+        (read-file-name "In directory: "
                         (file-name-directory (color-rg-search-dir color-rg-cur-search)) nil))
   (color-rg-rerun))
 


### PR DESCRIPTION
另外，在修改时，有几个函数的用途不是很懂，我估计可能有其他人也有一样的疑问，可否在文档中详细说明下。


```cl
(define-key map (kbd "C-a") 'color-rg-beginning-of-line)  ;; 这个在搜索匹配结果页面跳到行首？ 不知道有啥用。
(define-key map (kbd "SPC") 'color-rg-open-file)   ;; 这个在什么时候用到？我感觉我按下 TAB 的时候，已经 open 了？
(define-key map (kbd "i") 'color-rg-insert-current-line) ;; 实在是没看出来这是在替换什么？
```