### PR TITLE
fix: color-rg-project-root-dir in emacs 29

### DIFF
--- a/color-rg.el
+++ b/color-rg.el
@@ -1213,10 +1213,14 @@ This assumes that `color-rg-in-string-p' has already returned true, i.e.
 (defun color-rg-project-root-dir ()
   (let ((project (project-current)))
     (if project
-        (if (version< emacs-version "27.0")
-            (expand-file-name (cdr project))
-          (expand-file-name (car (last project))))
-      default-directory)))
+        (cond
+         ;; 27 <= <= 28
+         ((and
+           (version< "27" emacs-version)
+           (version< emacs-version "29")) (expand-file-name (cdr project)))
+         ;; >= 29
+         ((version<= "29" emacs-version) (expand-file-name (car (last project))))
+         (t default-directory)))))
 
 (defalias 'color-rg-search-input-in-project 'color-rg-search-project)
 

--- a/color-rg.el
+++ b/color-rg.el
@@ -1213,7 +1213,7 @@ This assumes that `color-rg-in-string-p' has already returned true, i.e.
 (defun color-rg-project-root-dir ()
   (let ((project (project-current)))
     (if project
-        (if (version< "27.0" emacs-version)
+        (if (version< emacs-version "27.0")
             (expand-file-name (cdr project))
           (expand-file-name (car (last project))))
       default-directory)))


### PR DESCRIPTION
27+ should use (car (last project)) to get project dir str
so switch the condition

29运行时发现此处的版本判断顺序应当调整一下，或直接调整if代码块中内容，但调整判断顺序更为便捷