### PR TITLE
fix: 替换结果时可能出现的误触问题

### DIFF
--- a/color-rg.el
+++ b/color-rg.el
@@ -1245,6 +1245,7 @@ This assumes that `color-rg-in-string-p' has already returned true, i.e.
   (color-rg-search-input (color-rg-read-input) (concat (color-rg-project-root-dir) "app") (color-rg-read-file-type "Filter file by type (default: [ %s ]): ")))
 
 (defun color-rg-replace-all-matches ()
+  "Replace all matched results."
   (interactive)
   (save-excursion
     (let (changed-line-number)
@@ -1259,8 +1260,8 @@ This assumes that `color-rg-in-string-p' has already returned true, i.e.
             (setq changed-line-number (length color-rg-changed-lines))
             (color-rg-apply-changed)
             (color-rg-switch-to-view-mode)
-            (setf (color-rg-search-keyword color-rg-cur-search) replace-text)
-            )))
+            (when (> changed-line-number 0)
+              (setf (color-rg-search-keyword color-rg-cur-search) replace-text)))))
       (message "Replace %s lines" changed-line-number))))
 
 (defun color-rg-filter-match-results ()


### PR DESCRIPTION
复现过程如下：

1. `emacs -Q color-rg.el -l color-rg.el`

2. 通过 `color-rg-search-input` 搜索 `color-rg`

3. 出结果后按下`r`键替换，在已有`color-rg`的基础上改为`color-rgrg`，回车

4. 按下`a`键（随意，只要不是 Emacs 默认的替换相关 `y`, `n`, `!` 按键）， 出现 buffer is read only 报错

5. 再按`r`键替换，可以看到在没有替换的情况下，原本的 `Replace 'color-rg' all matches with: color-rg` 变成了 `Replace 'color-rgrg' all matches with: color-rgrg`

通过检查修改的行数，可以避免在没进行修改的情况下替换了对应的 `color-rg-search-keyword` 的情况

---

顺便问下，我用 `color-rg` 修改文件时有遇到需要修改很多文件的情况，与这个插件类似的 `wgrep` 有个 `wgrep-save-all-buffers` 的函数，可以批量保存所有通过 `wgrep` 修改过的文件，大佬你在遇到这种情况是怎么做的？一个个进修改过的文件去手动保存吗？