### PR TITLE
[feature] looping back to the beginning when reaching the end

### DIFF
--- a/color-rg.el
+++ b/color-rg.el
@@ -1438,7 +1438,10 @@ This function is the opposite of `color-rg-rerun-change-globs'"
         (progn
           (goto-char next-position)
           (color-rg-open-file))
-      (message "Reach to last line."))))
+      (progn
+        (message "Reach to the last line.")
+        (goto-char (point-min))
+        (call-interactively #'color-rg-jump-next-keyword)))))
 
 (defun color-rg-jump-prev-keyword ()
   (interactive)


### PR DESCRIPTION
When the point reaches the end of searching for candidates, go back to the beginning of the search panel.

Side-effects unknown.