### PR TITLE
Add color-rg-rerun-in-project

### DIFF
--- a/color-rg.el
+++ b/color-rg.el
@@ -1383,6 +1383,13 @@ This function is the opposite of `color-rg-rerun-change-globs'"
         (file-name-directory (directory-file-name (color-rg-search-dir color-rg-cur-search))))
   (color-rg-rerun))
 
+(defun color-rg-rerun-in-project ()
+  "Rerun last command in project root."
+  (interactive)
+  (setf (color-rg-search-dir color-rg-cur-search)
+        (file-name-directory (color-rg-project-root-dir)))
+  (color-rg-rerun))
+
 (defun color-rg-rerun-change-dir ()
   "Rerun last command but prompt for new dir."
   (interactive)

--- a/color-rg.el
+++ b/color-rg.el
@@ -499,8 +499,9 @@ used to restore window configuration after file content changed.")
     (define-key map (kbd "E") 'color-rg-rerun-change-exclude-files)
 
     (define-key map (kbd "o") 'color-rg-rerun-parent-dir)
-    (define-key map (kbd "O") 'color-rg-rerun-change-dir)
+    (define-key map (kbd "O") 'color-rg-rerun-in-project)
 
+    (define-key map (kbd "s") 'color-rg-rerun-change-dir)
     (define-key map (kbd "S") 'color-rg-customized-search)
 
     (define-key map (kbd "q") 'color-rg-quit)


### PR DESCRIPTION
Fixed #76 

增加了 color-rg-rerun-in-project, 并且快捷键做了一点小调整，主要让上一级目录 o 和 project_root O 用同一个快捷键。

要是觉得不合适，可以 revert.