### PR TITLE
fix: path problem under Windows

### DIFF
--- a/color-rg.el
+++ b/color-rg.el
@@ -652,9 +652,9 @@ This function is called from `compilation-filter-hook'."
 (cl-defstruct (color-rg-search (:constructor color-rg-search-create)
                                (:constructor color-rg-search-new (pattern dir))
                                (:copier nil))
-  keyword           ; search keyword
-  dir               ; base directory
-  globs             ; filename only match these globs will be searched
+  keyword             ; search keyword
+  dir                 ; base directory
+  globs               ; filename only match these globs will be searched
   file-exclude ; toggle exclude files, t means filename NOT match the globs will be searched
   literal      ; literal patterh (t or nil)
   case-sensitive                        ; case-sensitive (t or nil)
@@ -1195,9 +1195,7 @@ This assumes that `color-rg-in-string-p' has already returned true, i.e.
           (or globs
               "everything")))
     (color-rg-search search-keyboard
-                     (if (string-equal system-type "windows-nt")
-                         (format "\"%s\"" search-directory)
-                       search-directory)
+                     search-directory
                      search-globs)))
 
 (defun color-rg-search-symbol ()
@@ -1395,8 +1393,11 @@ This function is the opposite of `color-rg-rerun-change-globs'"
   "Rerun last command but prompt for new dir."
   (interactive)
   (setf (color-rg-search-dir color-rg-cur-search)
-        (read-file-name "In directory: "
-                        (file-name-directory (color-rg-search-dir color-rg-cur-search)) nil))
+        (expand-file-name
+         (read-file-name
+          "In directory: "
+          (file-name-directory (color-rg-search-dir color-rg-cur-search))
+          nil)))
   (color-rg-rerun))
 
 (defun color-rg-rerun-literal (&optional nointeractive)


### PR DESCRIPTION
更新了最新的版本后，我用 Windows 在 color-rg 页面下按 s 试用的时候发现路径有问题

<img width="453" alt="Snipaste_2022-11-09_13-30-56" src="https://user-images.githubusercontent.com/25452934/200746805-4f834cac-aef2-44a2-ac70-05d76a7b4d03.png">

看了下相关的处理，不知道为什么要在 Windows 平台下额外加个双引号，这会导致后续处理出问题

<img width="645" alt="Snipaste_2022-11-09_13-32-45" src="https://user-images.githubusercontent.com/25452934/200747070-d9b68c46-5fa6-46b5-a786-5106fc4deef1.png">

可以看到在 `color-rg-cur-search` 这个变量里是加了引号的路径，对这个路径使用 `file-name-directory` 就会出现第一张图所出现的结果

<img width="526" alt="Snipaste_2022-11-09_13-34-18" src="https://user-images.githubusercontent.com/25452934/200747355-85f16589-1183-442f-a236-d688247eb2a5.png">

去掉对 Windows 特有的处理后，一切就正常了，但还有个小问题，在 Windows 下使用 rg 搜索 `~` 目录会搜索不到

<img width="964" alt="Snipaste_2022-11-09_13-26-04" src="https://user-images.githubusercontent.com/25452934/200747524-c6f6cd96-80da-4f73-a4b7-87bb68514805.png">

所以又做了一次 `expand-file-name` 的处理，这样改完后，我在 Windows 下和 wsl 下操作都正常了