### PR TITLE
fix: avoid space in folder name problem

### DIFF
--- a/color-rg.el
+++ b/color-rg.el
@@ -762,7 +762,7 @@ CASE-SENSITIVE determinies if search is case-sensitive."
                 (list "--type-not <F>")
               (list "--type <F>")))
 
-          (list "-e <R>" (color-rg-filter-tramp-path dir)))))
+          (list "-e <R>" (format "\"%s\"" (color-rg-filter-tramp-path dir))))))
 
     (setq command-line
           (grep-expand-template
@@ -773,15 +773,15 @@ CASE-SENSITIVE determinies if search is case-sensitive."
       (setq command-line (encode-coding-string command-line locale-coding-system)))
     command-line))
 
-(defun color-rg-filter-tramp-path (x)
-  "Remove sudo from path.  Argument X is path."
+(defun color-rg-filter-tramp-path (path)
+  "Remove sudo from PATH."
   (if (and (boundp 'tramp-tramp-file-p)
-           (tramp-tramp-file-p x))
-      (let ((tx (tramp-dissect-file-name x)))
-        (if (string-equal "sudo" (tramp-file-name-method tx))
-            (tramp-file-name-localname tx)
-          x))
-    x))
+           (tramp-tramp-file-p path))
+      (let ((tramp-path (tramp-dissect-file-name path)))
+        (if (string-equal "sudo" (tramp-file-name-method tramp-path))
+            (tramp-file-name-localname tramp-path)
+          path))
+    path))
 
 (defun color-rg-search (keyword directory globs &optional literal no-ignore no-node case-sensitive file-exclude)
   (let* ((command (color-rg-build-command keyword directory globs literal no-ignore no-node case-sensitive file-exclude)))


### PR DESCRIPTION
在文件夹名字中带有空格的文件夹路径下搜索时，需要将路径用双引号括起来

- 现在：

![图片](https://user-images.githubusercontent.com/25452934/200755845-2157a182-23e6-4ab7-95f0-e8c984e5a100.png)  

- 添加括号后：  

![图片](https://user-images.githubusercontent.com/25452934/200758120-620622cd-9c86-4f59-bb87-7e7dca623d87.png)  

---

非常好奇的一点是 rg 里 `-e <R>` 的操作，在 Windows 下会默认全都用双引号包裹，在 wsl 下则是用 `\` 转义 

![图片](https://user-images.githubusercontent.com/25452934/200757642-0d7fd684-c2d1-4204-b505-e576b3a1ec65.png) 