### PR TITLE
fix line scroll when scroll-preserve-screen-position is on

### DIFF
--- a/color-rg.el
+++ b/color-rg.el
@@ -1631,7 +1631,8 @@ If STAY is non-nil, move cursor to the opened file."
 
   ;; Scroll current point to first line of window.
   (set-window-start (get-buffer-window) (point))
-  (scroll-down-line 5))
+  (save-excursion
+    (scroll-down-line (min 5 (1- (window-body-height))))))
 
 (defun color-rg-move-to-column (column)
   (beginning-of-line)


### PR DESCRIPTION
When `scroll-preserve-screen-position` is on, the actual line that the cursor is at is 5 lines away from the target line.
The PR fixes the line scroll in `color-rg-move-to-point` to lock the cursor position.