### PR TITLE
fix *color-rg temp* buffer does not exit error

### DIFF
--- a/color-rg.el
+++ b/color-rg.el
@@ -1099,12 +1099,11 @@ This assumes that `color-rg-in-string-p' has already returned true, i.e.
 
 (defun color-rg-clone-to-temp-buffer ()
   (color-rg-kill-temp-buffer)
-  (when (buffer-live-p color-rg-buffer)
+  (when (get-buffer color-rg-buffer)
     (with-current-buffer color-rg-buffer
       (add-hook 'kill-buffer-hook 'color-rg-kill-temp-buffer nil t)
       (generate-new-buffer color-rg-temp-buffer)
-      (append-to-buffer color-rg-temp-buffer (point-min) (point-max))
-      )))
+      (append-to-buffer color-rg-temp-buffer (point-min) (point-max)))))
 
 (defun color-rg-switch-to-view-mode ()
   (interactive)


### PR DESCRIPTION
Directlly pass  name of a buffer to function `buffer-live-p` will always return nil, cause the argument type of this function should be `buffer object` .

> (buffer-live-p OBJECT)
> Return t if OBJECT is a buffer which has not been killed.
> Value is nil if OBJECT is not a buffer or if it has been killed.
